### PR TITLE
Update POM.xml to support Jenkins deployment

### DIFF
--- a/starter_code/pom.xml
+++ b/starter_code/pom.xml
@@ -6,11 +6,11 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>2.1.5.RELEASE</version>
-		<packaging>war</packaging>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
 	<artifactId>auth-course</artifactId>
+	<packaging>war</packaging>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>auth-course</name>
 	<description>Demo project for Spring Boot</description>

--- a/starter_code/pom.xml
+++ b/starter_code/pom.xml
@@ -51,6 +51,10 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+ 		               	<groupId>org.apache.maven.plugins</groupId>
+                		<artifactId>maven-compiler-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/starter_code/pom.xml
+++ b/starter_code/pom.xml
@@ -54,6 +54,10 @@
 			<plugin>
  		               	<groupId>org.apache.maven.plugins</groupId>
                 		<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>11</source>
+					<target>11</target>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/starter_code/pom.xml
+++ b/starter_code/pom.xml
@@ -54,10 +54,6 @@
 			<plugin>
  		               	<groupId>org.apache.maven.plugins</groupId>
                 		<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>11</source>
-					<target>11</target>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/starter_code/pom.xml
+++ b/starter_code/pom.xml
@@ -6,6 +6,7 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>2.1.5.RELEASE</version>
+		<packaging>war</packaging>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/starter_code/pom.xml
+++ b/starter_code/pom.xml
@@ -44,6 +44,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.codehaus.mojo/tomcat-maven-plugin -->
+		<dependency>
+		    <groupId>org.codehaus.mojo</groupId>
+		    <artifactId>tomcat-maven-plugin</artifactId>
+		    <version>1.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Update POM.xml to support Jenkins deployment. Added the following:
1. Packaging tag in the maven-war-plugin
2. tomcat-maven-plugin as a dependency
3. maven-compiler-plugin in the plugins